### PR TITLE
sar_facts - improves module return docs

### DIFF
--- a/plugins/modules/sar_facts.py
+++ b/plugins/modules/sar_facts.py
@@ -86,34 +86,56 @@ EXAMPLES = r'''
 RETURN = r'''
 ansible_facts:
   description:
-    - A dictionary containing the SAR data collected. The key is dynamically determined based on the O(type).
-    - The dict name format is c(sar_<type>).
-    - The value is a list of dictionaries where each dictionary represents a single data point with the following keys
+    - A dictionary containing the SAR data collected.
+    - The value is a list of dictionaries where each dictionary represents a single data point.
     - V(date) The date for the measurement.
     - V(time) The time for the measurement in 24-hour format.
     - Additional keys corresponding to the performance metrics output from the C(sar) command.
   returned: always
-  type: dict
-  sample: {
-      "sar_cpu": [
-          {
-              "date": "2025-05-01",
-              "time": "08:00:00",
-              "AM": "AM",
-              "%user": "5.00",
-              "%system": "2.00",
-              "%idle": "93.00"
-          },
-          {
-              "date": "2025-05-01",
-              "time": "08:10:00",
-              "AM": "AM",
-              "%user": "6.00",
-              "%system": "3.00",
-              "%idle": "91.00"
-          }
-      ]
-  }
+  type: complex
+  contains:
+    sar_cpu:
+      description:
+        - Dictionary that contains C(cpu) data from C(sar).
+        - It contains V(date), V(time) and all others keys from C(sar) data.
+        - Most common keys are V(%user), V(%nice), V(%system), V(%idle) and others.
+      returned: when O(type) is V(cpu).
+      type: dict
+    sar_mem:
+      description:
+        - Dictionary that contains C(memory) data from C(sar).
+        - It contains V(date), V(time) and all others keys from C(sar) data.
+        - Most common keys are V(%memused), V(%commit) and others.
+      returned: when O(type) is V(memory).
+      type: dict
+    sar_swap:
+      description:
+        - Dictionary that contains C(swap) data from C(sar).
+        - It contains V(date), V(time) and all others keys from C(sar) data.
+        - Most common keys are V(%swpused), V(%swpcad) and others.
+      returned: when O(type) is V(swap).
+      type: dict
+    sar_net:
+      description:
+        - Dictionary that contains C(network) data from C(sar).
+        - It contains V(date), V(time) and all others keys from C(sar) data.
+        - Most common keys are V(IFACE), V(rxpck/s), V(txpck/s), v(%ifutil) and others.
+      returned: when O(type) is V(network).
+      type: dict
+    sar_disk:
+      description:
+        - Dictionary that contains C(disk) data from C(sar).
+        - It contains V(date), V(time) and all others keys from C(sar) data.
+        - Most common keys are V(DEV), V(%util), V(await), V(rkB/s), V(wkB/s) and others.
+      returned: when O(type) is V(disk).
+      type: dict
+    sar_load:
+      description:
+        - Dictionary that contains C(load) data from C(sar).
+        - It contains V(date), V(time) and all others keys from C(sar) data.
+        - Most common keys are V(ldavg-1), V(ldavg-5), V(ldavg-15) and others.
+      returned: when O(type) is V(load).
+      type: dict
 '''
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR improves the `return` module documentation

```python
RETURN = r'''
ansible_facts:
  description:
    - A dictionary containing the SAR data collected.
    - The value is a list of dictionaries where each dictionary represents a single data point.
    - V(date) The date for the measurement.
    - V(time) The time for the measurement in 24-hour format.
    - Additional keys corresponding to the performance metrics output from the C(sar) command.
  returned: always
  type: complex
  contains:
    sar_cpu:
      description:
        - Dictionary that contains C(cpu) data from C(sar).
        - It contains V(date), V(time) and all others keys from C(sar) data.
        - Most common keys are V(%user), V(%nice), V(%system), V(%idle) and others.
      returned: when O(type) is V(cpu).
      type: dict
    sar_mem:
      description:
        - Dictionary that contains C(memory) data from C(sar).
        - It contains V(date), V(time) and all others keys from C(sar) data.
        - Most common keys are V(%memused), V(%commit) and others.
      returned: when O(type) is V(memory).
      type: dict
    sar_swap:
      description:
        - Dictionary that contains C(swap) data from C(sar).
        - It contains V(date), V(time) and all others keys from C(sar) data.
        - Most common keys are V(%swpused), V(%swpcad) and others.
      returned: when O(type) is V(swap).
      type: dict
    sar_net:
      description:
        - Dictionary that contains C(network) data from C(sar).
        - It contains V(date), V(time) and all others keys from C(sar) data.
        - Most common keys are V(IFACE), V(rxpck/s), V(txpck/s), v(%ifutil) and others.
      returned: when O(type) is V(network).
      type: dict
    sar_disk:
      description:
        - Dictionary that contains C(disk) data from C(sar).
        - It contains V(date), V(time) and all others keys from C(sar) data.
        - Most common keys are V(DEV), V(%util), V(await), V(rkB/s), V(wkB/s) and others.
      returned: when O(type) is V(disk).
      type: dict
    sar_load:
      description:
        - Dictionary that contains C(load) data from C(sar).
        - It contains V(date), V(time) and all others keys from C(sar) data.
        - Most common keys are V(ldavg-1), V(ldavg-5), V(ldavg-15) and others.
      returned: when O(type) is V(load).
      type: dict
'''
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
sar_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```