### PR TITLE
udevadm_info - new module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -86,6 +86,8 @@ files:
     maintainers: NomakCooper
   $modules/sar_facts.py:
     maintainers: NomakCooper
+  $modules/udevadm_info.py:
+    maintainers: NomakCooper
 #########################
   tests/:
     labels: tests

--- a/plugins/modules/chrony_info.py
+++ b/plugins/modules/chrony_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: chrony_info
-short_description: Collect C(chrony) configuration and server info.
+short_description: Collect chrony configuration and server info.
 description:
   - Retrieves C(chrony) information using C(chronyd) and C(chronyc) commands.
   - Collects C(configuration), C(sources), C(sourcestat) and C(ntpdata) info based on O(mode) option.

--- a/plugins/modules/udevadm_info.py
+++ b/plugins/modules/udevadm_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: udevadm_info
-short_description: Collect udevadm device info.
+short_description: Collect udevadm device information.
 description:
   - Retrieves C(udevadm) information using C(udevadm info) commands.
   - Collects all properties avaible in udevadm for the selected device.

--- a/plugins/modules/udevadm_info.py
+++ b/plugins/modules/udevadm_info.py
@@ -1,0 +1,359 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: udevadm_info
+short_description: Collect udevadm device info.
+description:
+  - Retrieves C(udevadm) information using C(udevadm info) commands.
+  - Collects all properties avaible in udevadm for the selected device.
+version_added: "0.2.0"
+options:
+  device:
+    description:
+      - Device full name.
+      - O(device) is passed as an argument to the C(udevadm) command, so the name must be complete.
+      - For example for C(sda) disk you must use the full name V(/dev/sda).
+    required: true
+    type: str
+  property:
+    description:
+      - This option is used if you want to collect only a specific property of the specified O(device).
+      - For example you can collect only the V(DEVTYPE) property.
+    required: false
+    type: str
+requirements:
+  - C(udevadm info) command with C(-x), C(--query), C(--property) and C(--name) options.
+author:
+  - Marco Noce (@NomakCooper)
+notes:
+  - Module requires C(register) function in order to access to the collected info.
+  - Some device properties, like V(DEVLINKS), can have multiple values,
+    so the module will report the values of that specific property as a C(list) rather than as a C(string).
+'''
+
+EXAMPLES = r'''
+---
+# Get full udevadm info for /dev/sda
+- name: Get full udevadm info for /dev/sda
+  ans2dev.general.udevadm_info:
+    device: "/dev/sda"
+  register: result
+
+# Print SCSI_VENDOR from example above
+- name: Print SCSI_VENDOR of /dev/sda
+  ansible.builtin.debug:
+    var: result.udevinfo.SCSI_VENDOR
+
+# Get only DEVPATH property from udevadm info for /dev/sda
+- name: Get only DEVPATH property from udevadm info for /dev/sda
+  ans2dev.general.udevadm_info:
+    device: "/dev/sda"
+    property: "DEVPATH"
+  register: result
+'''
+
+RETURN = r'''
+udevinfo:
+  description:
+    - Dictionary of C(udevadm info) properties.
+    - Additional fields will be returned depending on C(udevadm) version or OS distribution.
+  returned: success
+  type: dict
+  elements: dict
+  contains:
+    DEVPATH:
+      description:
+        - The C(sysfs) path of the device in the Linux device tree.
+        - Indicates its physical location.
+      returned: always
+      type: str
+      sample: "/devices/pci0000:00/0000:00:03.0/virtio0/host0/target0:0:1/0:0:1:0/block/sda"
+    DEVNAME:
+      description:
+        - The device node name in /dev used for interacting with the device.
+      returned: always
+      type: str
+      sample: "/dev/sda"
+    DEVTYPE:
+      description:
+        - Specifies the type of device.
+      returned: always
+      type: str
+      sample: "disk"
+    DISKSEQ:
+      description:
+        - A sequence number assigned to the disk, which can be used for ordering.
+      returned: always
+      type: str
+      sample: "9"
+    MAJOR:
+      description:
+        - The major device number identifying the kernel driver associated with the device.
+      returned: always
+      type: str
+      sample: "8"
+    MINOR:
+      description:
+        - The minor device number that distinguishes between devices handled by the same driver.
+      returned: always
+      type: str
+      sample: "0"
+    SUBSYSTEM:
+      description:
+        - Indicates the kernel subsystem to which the device belongs.
+      returned: always
+      type: str
+      sample: "block"
+    USEC_INITIALIZED:
+      description:
+        - A microsecond timestamp indicating when udev initialized the device.
+      returned: always
+      type: str
+      sample: "3900986"
+    SCSI_TPGS:
+      description:
+        - Indicates SCSI Target Port Group Support.
+      returned: always
+      type: str
+      sample: "0"
+    SCSI_TYPE:
+      description:
+        - Specifies the SCSI device type.
+      returned: always
+      type: str
+      sample: "disk"
+    SCSI_VENDOR:
+      description:
+        - The vendor name of the SCSI device.
+      returned: always
+      type: str
+      sample: "Google"
+    SCSI_VENDOR_ENC:
+      description:
+        - Encoded vendor name of the SCSI device, with escape sequences for special characters.
+      returned: always
+      type: str
+      sample: "Google\\x20\\x20"
+    SCSI_MODEL:
+      description:
+        - The model identifier of the SCSI device.
+      returned: always
+      type: str
+      sample: "PersistentDisk"
+    SCSI_MODEL_ENC:
+      description:
+        - Encoded version of the SCSI model, including escape sequences where needed.
+      returned: always
+      type: str
+      sample: "PersistentDisk\\x20\\x20"
+    SCSI_REVISION:
+      description:
+        - Specifies the hardware or firmware revision of the SCSI device.
+      returned: always
+      type: str
+      sample: "1"
+    ID_SCSI:
+      description:
+        - A flag confirming that the device was identified by the SCSI subsystem.
+      returned: always
+      type: str
+      sample: "1"
+    ID_SCSI_INQUIRY:
+      description:
+        - Indicates that a SCSI inquiry command was successfully executed on the device.
+      returned: always
+      type: str
+      sample: "1"
+    SCSI_IDENT_LUN_VENDOR:
+      description:
+        - Combines SCSI identification details and LUN vendor information to aid in device grouping.
+      returned: always
+      type: str
+      sample: "workspace"
+    ID_VENDOR:
+      description:
+        - Provides the vendor identifier for the device, similar to RV(udevinfo.SCSI_VENDOR).
+      returned: always
+      type: str
+      sample: "Google"
+    ID_VENDOR_ENC:
+      description:
+        - Encoded vendor identifier, with escape sequences for any special characters.
+      returned: always
+      type: str
+      sample: "Google\\x20\\x20"
+    ID_MODEL:
+      description:
+        - Identifies the device model, analogous to RV(udevinfo.SCSI_MODEL).
+      returned: always
+      type: str
+      sample: "PersistentDisk"
+    ID_MODEL_ENC:
+      description:
+        - Encoded version of the device model, including escape sequences if necessary.
+      returned: always
+      type: str
+      sample: "PersistentDisk\\x20\\x20"
+    ID_REVISION:
+      description:
+        - The revision number, firmware or hardware, of the device.
+      returned: always
+      type: str
+      sample: "1"
+    ID_TYPE:
+      description:
+        - Specifies the general type of the device.
+      returned: always
+      type: str
+      sample: "disk"
+    ID_BUS:
+      description:
+        - Indicates the bus type used by the device.
+      returned: always
+      type: str
+      sample: "scsi"
+    ID_SERIAL:
+      description:
+        - A unique serial number assigned to the device for identification purposes.
+      returned: always
+      type: str
+      sample: "0Google_PersistentDisk_workspace"
+    ID_SERIAL_SHORT:
+      description:
+        - A shortened version of the device serial number for simpler reference.
+      returned: always
+      type: str
+      sample: "workspace"
+    MPATH_SBIN_PATH:
+      description:
+        - Specifies the path to the multipath binaries, used in environments managing multipath storage.
+      returned: always
+      type: str
+      sample: "/sbin"
+    DM_MULTIPATH_DEVICE_PATH:
+      description:
+        - Indicates the status or state of the device under device-mapper multipath management.
+      returned: always
+      type: str
+      sample: "0"
+    ID_PATH:
+      description:
+        - Provides a unique, stable path to the device based on its physical bus location.
+      returned: always
+      type: str
+      sample: "pci-0000:00:03.0-scsi-0:0:1:0"
+    ID_PATH_TAG:
+      description:
+        - A sanitized version of RV(udevinfo.ID_PATH) that is safe for use as a tag or filename.
+      returned: always
+      type: str
+      sample: "pci-0000_00_03_0-scsi-0_0_1_0"
+    ID_PART_TABLE_UUID:
+      description:
+        - The universally unique identifier C(UUID) of the disk partition table, critical for GPT disks.
+      returned: always
+      type: str
+      sample: "942239ee-556f-4244-af35-7f6516dba76f"
+    ID_PART_TABLE_TYPE:
+      description:
+        - pecifies the type of partition table, such as GPT or MBR.
+      returned: always
+      type: str
+      sample: "gpt"
+    DEVLINKS:
+      description:
+        - A list of symlink paths generated by udev for stable device naming.
+      returned: always
+      type: list
+      elements: str
+      sample:
+        - "/dev/disk/by-path/pci-0000:00:03.0-scsi-0:0:1:0"
+        - "/dev/disk/by-id/scsi-0Google_PersistentDisk_workspace"
+        - "/dev/disk/by-diskseq/9"
+        - "/dev/disk/by-id/google-workspace"
+    TAGS:
+      description:
+        - Metadata tags applied to the device by udev, used for classification and rule matching.
+      returned: always
+      type: str
+      sample: ":systemd:"
+    CURRENT_TAGS:
+      description:
+        - The set of currently active tags on the device, indicating its runtime state.
+      returned: always
+      type: str
+      sample: ":systemd:"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import re
+
+
+def run_udevadm(module, device, prop, udevadm_cmd):
+
+    cmd = [udevadm_cmd, "info", "-x", "--no-pager", "--query=property"]
+    if prop:
+        cmd.append("--property=" + prop)
+    cmd.append("--name=" + device)
+
+    rc, stdout, stderr = module.run_command(cmd)
+
+    if rc != 0:
+        module.fail_json(msg="Error running udevadm", rc=rc, stderr=stderr, cmd=' '.join(cmd))
+
+    return parse_output(stdout)
+
+
+def parse_output(output):
+    info = {}
+
+    for line in output.splitlines():
+        line = line.strip()
+
+        if not line:
+            continue
+
+        m = re.match(r"^(\S+)=['\"](.*)['\"]$", line)
+
+        if m:
+            key = m.group(1)
+            value = m.group(2)
+            values = [v for v in value.split() if v]
+
+            if len(values) == 1:
+                info[key] = values[0]
+            elif len(values) > 1:
+                info[key] = values
+            else:
+                info[key] = value
+    return info
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            device=dict(required=True, type='str'),
+            property=dict(required=False, type='str')
+        ),
+        supports_check_mode=True
+    )
+
+    device = module.params.get("device")
+    prop = module.params.get("property")
+    udevadm_cmd = module.get_bin_path('udevadm', required=True)
+
+    udevinfo = run_udevadm(module, device, prop, udevadm_cmd)
+    module.exit_json(changed=False, udevinfo=udevinfo)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,0 +1,2 @@
+[testgroup]
+testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/usr/bin/python3"

--- a/tests/integration/targets/sar_facts/tasks/tests.yml
+++ b/tests/integration/targets/sar_facts/tasks/tests.yml
@@ -5,7 +5,7 @@
 - name: Check if SAR binary exists on the system
   ansible.builtin.command: "which sar"
   register: sar_bin
-  ignore_errors: yes
+  ignore_errors: true
   failed_when: false
 
 - name: Skip SAR facts test if SAR binary is not available

--- a/tests/integration/targets/udevadm_info/tasks/main.yml
+++ b/tests/integration/targets/udevadm_info/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Test sar_facts
+  block:
+
+  - name: Run tests
+    import_tasks: tests.yml

--- a/tests/integration/targets/udevadm_info/tasks/tests.yml
+++ b/tests/integration/targets/udevadm_info/tasks/tests.yml
@@ -1,0 +1,59 @@
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Check if udevadm binary exists on the system
+  ansible.builtin.command: "which udevadm"
+  register: udevadm_bin
+  ignore_errors: true
+  failed_when: false
+
+- name: Skip udevadm facts test if udevadm binary is not available
+  meta: end_play
+  when: udevadm_bin.rc != 0
+
+- name: "Test: Collect full udevadm info for /dev/sda"
+  ans2dev.general.udevadm_info:
+    device: "/dev/sda"
+  register: full_info
+
+- name: "Display full udevadm info"
+  debug:
+    var: full_info.udevinfo
+
+- name: "Assert that DEVPATH exists and is valid"
+  assert:
+    that:
+      - "'DEVPATH' in full_info.udevinfo"
+      - full_info.udevinfo.DEVPATH is match('^/devices/')
+
+- name: "Test: Collect only DEVTYPE property for /dev/sda"
+  ans2dev.general.udevadm_info:
+    device: "/dev/sda"
+    property: "DEVTYPE"
+  register: devtype_info
+
+- name: "Display DEVTYPE property"
+  debug:
+    var: devtype_info.udevinfo
+
+- name: "Assert that DEVTYPE equals 'disk'"
+  assert:
+    that:
+      - devtype_info.udevinfo.DEVTYPE == "disk"
+
+- name: "Test: Collect only DEVLINKS property for /dev/sda"
+  ans2dev.general.udevadm_info:
+    device: "/dev/sda"
+    property: "DEVLINKS"
+  register: devlinks_info
+
+- name: "Display DEVLINKS property"
+  debug:
+    var: devlinks_info.udevinfo
+
+- name: "Assert that DEVLINKS is a list with at least one element"
+  assert:
+    that:
+      - devlinks_info.udevinfo.DEVLINKS is iterable
+      - devlinks_info.udevinfo.DEVLINKS | length > 0

--- a/tests/unit/plugins/modules/test_udevadm_info.py
+++ b/tests/unit/plugins/modules/test_udevadm_info.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from ansible_collections.ans2dev.general.plugins.modules import udevadm_info  # type: ignore
+
+
+def exit_json(*args, **kwargs):
+    raise Exception("exit_json called: " + str(kwargs))
+
+
+def fail_json(*args, **kwargs):
+    raise Exception("fail_json called: " + str(kwargs))
+
+
+class TestUdevadmInfoModule(unittest.TestCase):
+    def run_udev_test(self, test_params, fake_output, expected_fact_key, expected_sample_value):
+        with patch('ansible_collections.ans2dev.general.plugins.modules.udevadm_info.AnsibleModule') as mock_AnsibleModule:
+            fake_module = MagicMock()
+            fake_module.params = test_params
+            fake_module.exit_json.side_effect = exit_json
+            fake_module.fail_json.side_effect = fail_json
+            fake_module.run_command.return_value = (0, fake_output, "")
+            fake_module.get_bin_path.return_value = "/usr/sbin/udevadm"
+            mock_AnsibleModule.return_value = fake_module
+
+            with self.assertRaises(Exception) as context:
+                udevadm_info.main()
+            result_str = str(context.exception)
+            self.assertIn(expected_fact_key, result_str)
+            self.assertIn(expected_sample_value, result_str)
+
+    def test_full_info(self):
+        fake_output = (
+            "DEVPATH='/devices/pci0000:00/0000:00:03.0/virtio0/host0/target0:0:1/0:0:1:0/block/sda'\n"
+            "DEVNAME='/dev/sda'\n"
+            "DEVTYPE='disk'\n"
+            "DEVLINKS='/dev/disk/by-path/path1 /dev/disk/by-id/id1'\n"
+        )
+        test_params = {"device": "/dev/sda"}
+        self.run_udev_test(
+            test_params,
+            fake_output,
+            "DEVPATH",
+            "/devices/pci0000:00/0000:00:03.0/virtio0/host0/target0:0:1/0:0:1:0/block/sda"
+        )
+
+    def test_specific_property(self):
+        fake_output = "DEVTYPE='disk'\n"
+        test_params = {"device": "/dev/sda", "property": "DEVTYPE"}
+        self.run_udev_test(test_params, fake_output, "DEVTYPE", "disk")
+
+    def test_multivalued_property(self):
+        fake_output = "DEVLINKS='/dev/disk/by-path/path1 /dev/disk/by-id/id1 /dev/disk/by-id/id2'\n"
+        test_params = {"device": "/dev/sda", "property": "DEVLINKS"}
+        with patch('ansible_collections.ans2dev.general.plugins.modules.udevadm_info.AnsibleModule') as mock_AnsibleModule:
+            fake_module = MagicMock()
+            fake_module.params = test_params
+            fake_module.exit_json.side_effect = exit_json
+            fake_module.fail_json.side_effect = fail_json
+            fake_module.run_command.return_value = (0, fake_output, "")
+            fake_module.get_bin_path.return_value = "/usr/sbin/udevadm"
+            mock_AnsibleModule.return_value = fake_module
+
+            with self.assertRaises(Exception) as context:
+                udevadm_info.main()
+            result_str = str(context.exception)
+
+            self.assertIn("DEVLINKS", result_str)
+            self.assertIn("['/dev/disk/by-path/path1', '/dev/disk/by-id/id1', '/dev/disk/by-id/id2']", result_str)
+
+    def test_fail_command(self):
+        fake_output = ""
+        test_params = {"device": "/dev/sda"}
+        with patch('ansible_collections.ans2dev.general.plugins.modules.udevadm_info.AnsibleModule') as mock_AnsibleModule:
+            fake_module = MagicMock()
+            fake_module.params = test_params
+            fake_module.exit_json.side_effect = exit_json
+            fake_module.fail_json.side_effect = fail_json
+            fake_module.run_command.return_value = (1, fake_output, "Error executing command")
+            fake_module.get_bin_path.return_value = "/usr/sbin/udevadm"
+            mock_AnsibleModule.return_value = fake_module
+
+            with self.assertRaises(Exception) as context:
+                udevadm_info.main()
+            result_str = str(context.exception)
+            self.assertIn("fail_json called", result_str)
+            self.assertIn("Error executing command", result_str)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add the new `udevadm_info` module and olso fix old tests and docs.

- Added new `udevadm_info` module
- Added new `unit` tests
- Added new `integration` tests
- Updated `BOTMETA.yml`

example:
```yaml
# Get full udevadm info for /dev/sda
- name: Get full udevadm info for /dev/sda
  ans2dev.general.udevadm_info:
    device: "/dev/sda"
  register: result

# Print SCSI_VENDOR from example above
- name: Print SCSI_VENDOR of /dev/sda
  ansible.builtin.debug:
    var: result.udevinfo.SCSI_VENDOR

# Get only DEVPATH property from udevadm info for /dev/sda
- name: Get only DEVPATH property from udevadm info for /dev/sda
  ans2dev.general.udevadm_info:
    device: "/dev/sda"
    property: "DEVPATH"
  register: result
```

example task print:
```bash
TASK [Display complete udevadm info] *********************************************************************************
ok: [localhost] => {
    "result.udevinfo": {
        "CURRENT_TAGS": ":systemd:",
        "DEVLINKS": [
            "/dev/disk/by-path/pci-0000:00:03.0-scsi-0:0:1:0",
            "/dev/disk/by-id/google-workspace",
            "/dev/disk/by-id/scsi-0Google_PersistentDisk_workspace",
            "/dev/disk/by-diskseq/9"
        ],
        "DEVNAME": "/dev/sda",
        "DEVPATH": "/devices/pci0000:00/0000:00:03.0/virtio0/host0/target0:0:1/0:0:1:0/block/sda",
        "DEVTYPE": "disk",
        "DISKSEQ": "9",
        "DM_MULTIPATH_DEVICE_PATH": "0",
        "ID_BUS": "scsi",
        "ID_MODEL": "PersistentDisk",
        "ID_MODEL_ENC": "PersistentDisk\\x20\\x20",
        "ID_PART_TABLE_TYPE": "gpt",
        "ID_PART_TABLE_UUID": "942239ee-556f-4244-af35-7f6516dba76f",
        "ID_PATH": "pci-0000:00:03.0-scsi-0:0:1:0",
        "ID_PATH_TAG": "pci-0000_00_03_0-scsi-0_0_1_0",
        "ID_REVISION": "1",
        "ID_SCSI": "1",
        "ID_SCSI_INQUIRY": "1",
        "ID_SERIAL": "0Google_PersistentDisk_workspace",
        "ID_SERIAL_SHORT": "workspace",
        "ID_TYPE": "disk",
        "ID_VENDOR": "Google",
        "ID_VENDOR_ENC": "Google\\x20\\x20",
        "MAJOR": "8",
        "MINOR": "0",
        "MPATH_SBIN_PATH": "/sbin",
        "SCSI_IDENT_LUN_VENDOR": "workspace",
        "SCSI_MODEL": "PersistentDisk",
        "SCSI_MODEL_ENC": "PersistentDisk\\x20\\x20",
        "SCSI_REVISION": "1",
        "SCSI_TPGS": "0",
        "SCSI_TYPE": "disk",
        "SCSI_VENDOR": "Google",
        "SCSI_VENDOR_ENC": "Google\\x20\\x20",
        "SUBSYSTEM": "block",
        "TAGS": ":systemd:",
        "USEC_INITIALIZED": "3900986"
    }
}
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
udevadm_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```