### PR TITLE
udevadm_control - add new module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -86,6 +86,8 @@ files:
     maintainers: NomakCooper
   $modules/sar_facts.py:
     maintainers: NomakCooper
+  $modules/udevadm_control.py:
+    maintainers: NomakCooper
   $modules/udevadm_info.py:
     maintainers: NomakCooper
   $modules/udevadm_verify.py:

--- a/plugins/modules/udevadm_control.py
+++ b/plugins/modules/udevadm_control.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: udevadm_control
+short_description: Reload udev rules.
+description:
+  - Reload udev rules using C(udevadm control) command.
+version_added: "0.2.0"
+options:
+  log_level:
+    description:
+      - Set C(--log-level) option value.
+    required: false
+    type: str
+    choices: [ emerg, alert, crit, err, warning, notice, info, debug ]
+requirements:
+  - C(udevadm control) command with C(--reload) and C(--log-level) options.
+author:
+  - Marco Noce (@NomakCooper)
+notes:
+  - Module requires C(register) function in order to access to the collected info.
+  - Module return RV(udevcontrol.stdout) and RV(udevcontrol.stderr) from C(udevadm control) command.
+'''
+
+EXAMPLES = r'''
+---
+# Reload udev rules
+- name: Reload udev rules
+  ans2dev.general.udevadm_control:
+    log_level: debug
+  register: result
+
+# Reload udev rules with debug level
+- name: Reload with debug log_level
+  ans2dev.general.udevadm_control:
+    log_level: debug
+  register: result
+'''
+
+RETURN = r'''
+udevcontrol:
+  description:
+    - C(udevadm control) output.
+  returned: always
+  type: dict
+  elements: dict
+  contains:
+    stdout:
+      description:
+        - C(udevadm control) stdout command.
+      returned: always
+      type: str
+      sample: ""
+    stderr:
+      description:
+        - C(udevadm control) stderr command.
+      returned: always
+      type: str
+      sample: ""
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def build_command(udevadm_path, log_level):
+    cmd = [udevadm_path, 'control', '--reload']
+    if log_level:
+        cmd.extend(['--log-level', log_level])
+    return cmd
+
+
+def run_udevadm_control(module, udevadm_path, log_level):
+    cmd = build_command(udevadm_path, log_level)
+    rc, out, err = module.run_command(cmd, check_rc=False)
+
+    if rc != 0:
+        module.fail_json(
+            msg="udevadm control command failed",
+            rc=rc,
+            stdout=out,
+            stderr=err
+        )
+
+    return {'stdout': out, 'stderr': err}
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            log_level=dict(
+                required=False,
+                type='str',
+                choices=['emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug']
+            ),
+        ),
+        supports_check_mode=True
+    )
+
+    log_level = module.params.get('log_level')
+    udevadm = module.get_bin_path('udevadm', required=True)
+
+    if module.check_mode:
+        module.exit_json(changed=True, udevcontrol={'stdout': '', 'stderr': ''})
+
+    result = run_udevadm_control(module, udevadm, log_level)
+
+    module.exit_json(changed=True, udevcontrol=result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/udevadm_control/tasks/main.yml
+++ b/tests/integration/targets/udevadm_control/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Test sar_facts
+  block:
+
+  - name: Run tests
+    import_tasks: tests.yml

--- a/tests/integration/targets/udevadm_control/tasks/tests.yml
+++ b/tests/integration/targets/udevadm_control/tasks/tests.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Check if udevadm binary exists on the system
+  ansible.builtin.command: "which udevadm"
+  register: udevadm_bin
+  ignore_errors: true
+  failed_when: false
+
+- name: Skip udevadm facts test if udevadm binary is not available
+  meta: end_play
+  when: udevadm_bin.rc != 0
+
+- name: Default reload (no log_level)
+  ans2dev.general.udevadm_control:
+  register: default_reload
+
+- name: Assert default reload succeeded
+  ansible.builtin.assert:
+    that:
+      - default_reload.changed
+      - default_reload.udevcontrol.stdout is defined
+      - default_reload.udevcontrol.stderr == ""
+
+- name: Reload with debug log_level
+  ans2dev.general.udevadm_control:
+    log_level: debug
+  register: debug_reload
+
+- name: Assert debug reload succeeded
+  ansible.builtin.assert:
+    that:
+      - debug_reload.changed
+      - debug_reload.udevcontrol.stdout is defined
+      - debug_reload.udevcontrol.stderr == ""
+
+- name: Check does not actually reload
+  ans2dev.general.udevadm_control:
+    log_level: info
+  check_mode: yes
+  register: checkmode_reload
+
+- name: Assert check behavior
+  ansible.builtin.assert:
+    that:
+      - checkmode_reload.changed
+      - checkmode_reload.udevcontrol.stdout == ""
+      - checkmode_reload.udevcontrol.stderr == ""

--- a/tests/unit/plugins/modules/test_udevadm_control.py
+++ b/tests/unit/plugins/modules/test_udevadm_control.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from ansible_collections.ans2dev.general.plugins.modules import udevadm_control  # type: ignore
+
+
+def exit_json(*args, **kwargs):
+    raise Exception("exit_json called: " + str(kwargs))
+
+
+def fail_json(*args, **kwargs):
+    raise Exception("fail_json called: " + str(kwargs))
+
+
+class TestUdevadmControlModule(unittest.TestCase):
+    def setUp(self):
+        patcher = patch(
+            'ansible_collections.ans2dev.general.plugins.modules.udevadm_control.AnsibleModule'
+        )
+        self.mock_module_class = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.fake_module = MagicMock()
+        self.fake_module.exit_json.side_effect = exit_json
+        self.fake_module.fail_json.side_effect = fail_json
+        self.mock_module_class.return_value = self.fake_module
+
+    def run_main(self):
+        with self.assertRaises(Exception) as exc:
+            udevadm_control.main()
+        return str(exc.exception)
+
+    def test_no_log_level(self):
+        self.fake_module.params = {'log_level': None}
+        self.fake_module.check_mode = False
+        self.fake_module.get_bin_path.return_value = '/usr/bin/udevadm'
+        self.fake_module.run_command.return_value = (0, 'reloaded', '')
+
+        result = self.run_main()
+
+        self.assertIn("'stdout': 'reloaded'", result)
+        self.assertIn("'stderr': ''", result)
+        self.fake_module.get_bin_path.assert_called_with('udevadm', required=True)
+        self.fake_module.run_command.assert_called_with(['/usr/bin/udevadm', 'control', '--reload'], check_rc=False)
+
+    def test_with_log_level(self):
+        self.fake_module.params = {'log_level': 'debug'}
+        self.fake_module.check_mode = False
+        self.fake_module.get_bin_path.return_value = '/usr/bin/udevadm'
+        self.fake_module.run_command.return_value = (0, 'reloaded debug', '')
+
+        result = self.run_main()
+        self.assertIn("'stdout': 'reloaded debug'", result)
+        self.fake_module.run_command.assert_called_with(
+            ['/usr/bin/udevadm', 'control', '--reload', '--log-level', 'debug'],
+            check_rc=False
+        )
+
+        def test_check_mode(self):
+            self.fake_module.params = {'log_level': 'info'}
+            self.fake_module.check_mode = True
+            result = self.run_main()
+            self.assertIn("'changed': True", result)
+            self.assertIn("'udevcontrol': {'stdout': '', 'stderr': ''}", result)
+            self.fake_module.run_command.assert_not_called()
+
+    def test_failure(self):
+        self.fake_module.params = {'log_level': None}
+        self.fake_module.check_mode = False
+        self.fake_module.get_bin_path.return_value = '/usr/bin/udevadm'
+        self.fake_module.run_command.return_value = (2, '', 'error occurred')
+
+        result = self.run_main()
+        self.assertIn('fail_json called', result)
+        self.assertIn("'stderr': 'error occurred'", result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds the new `udevadm_control` module.

Module reload `udev rules`.

Examples:
```yaml
# Reload udev rules
- name: Reload udev rules
  ans2dev.general.udevadm_control:
    log_level: debug
  register: result

# Reload udev rules with debug level
- name: Reload with debug log_level
  ans2dev.general.udevadm_control:
    log_level: debug
  register: result
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
udevadm_control
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```