### PR TITLE
udevadm_trigger - new module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -90,6 +90,8 @@ files:
     maintainers: NomakCooper
   $modules/udevadm_info.py:
     maintainers: NomakCooper
+  $modules/udevadm_trigger.py:
+    maintainers: NomakCooper
   $modules/udevadm_verify.py:
     maintainers: NomakCooper
 #########################

--- a/plugins/modules/udevadm_trigger.py
+++ b/plugins/modules/udevadm_trigger.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: udevadm_trigger
+short_description: Trigger udev rules.
+description:
+  - Trigger udev rules using C(udevadm trigger) command.
+version_added: "0.2.0"
+options:
+  quiet:
+    description:
+      - Set or not C(--quiet) option.
+    required: true
+    type: bool
+  type:
+    description:
+      - Set the type of events to trigger.
+    required: true
+    type: str
+    choices: [ all, devices, subsystems ]
+requirements:
+  - C(udevadm trigger) command with C(--quiet) and C(--type) options.
+author:
+  - Marco Noce (@NomakCooper)
+notes:
+  - Module requires C(register) function in order to access to the collected info.
+  - Module return RV(udevtrigger.stdout) and RV(udevtrigger.stderr) from C(udevadm trigger) command.
+'''
+
+EXAMPLES = r'''
+---
+# Trigger all events
+- name: Trigger all events
+  ans2dev.general.udevadm_trigger:
+    quiet: true
+    type: all
+  register: result
+
+# Trigger devices events without quiet
+- name: Trigger all events
+  ans2dev.general.udevadm_trigger:
+    quiet: false
+    type: devices
+  register: result
+
+# Trigger subsystems events
+- name: Trigger all events
+  ans2dev.general.udevadm_trigger:
+    quiet: true
+    type: subsystems
+  register: result
+'''
+
+RETURN = r'''
+udevtrigger:
+  description:
+    - C(udevadm trigger) output.
+  returned: always
+  type: dict
+  elements: dict
+  contains:
+    stdout:
+      description:
+        - C(udevadm trigger) stdout command.
+      returned: always
+      type: str
+      sample: ""
+    stderr:
+      description:
+        - C(udevadm trigger) stderr command.
+      returned: always
+      type: str
+      sample: ""
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+def build_command(binary, quiet, event_type):
+    cmd = [binary, 'trigger']
+    if quiet:
+        cmd.append('-q')
+    cmd.append(f"--type={event_type}")
+    return cmd
+
+
+def run_trigger(module, binary, quiet, event_type):
+    cmd = build_command(binary, quiet, event_type)
+    rc, out, err = module.run_command(cmd)
+    return rc, out, err
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            type=dict(required=True, type='str', choices=['all', 'devices', 'subsystems']),
+            quiet=dict(required=True, type='bool'),
+        ),
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        module.exit_json(changed=False)
+
+    event_type = module.params['type']
+    quiet = module.params['quiet']
+    binary = module.get_bin_path('udevadm', required=True)
+
+    try:
+        rc, out, err = run_trigger(module, binary, quiet, event_type)
+        if rc != 0:
+            module.fail_json(msg="udevadm trigger command failed", rc=rc, stdout=out, stderr=err)
+
+        module.exit_json(changed=True, udevtrigger={'stdout': out, 'stderr': err})
+    except Exception as e:
+        module.fail_json(msg="Unexpected error: %s" % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/udevadm_trigger/tasks/main.yml
+++ b/tests/integration/targets/udevadm_trigger/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Test sar_facts
+  block:
+
+  - name: Run tests
+    import_tasks: tests.yml

--- a/tests/integration/targets/udevadm_trigger/tasks/tests.yml
+++ b/tests/integration/targets/udevadm_trigger/tasks/tests.yml
@@ -1,0 +1,52 @@
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Check if udevadm binary exists on the system
+  ansible.builtin.command: "which udevadm"
+  register: udevadm_bin
+  ignore_errors: true
+  failed_when: false
+
+- name: Skip udevadm facts test if udevadm binary is not available
+  meta: end_play
+  when: udevadm_bin.rc != 0
+
+- name: Trigger all events quietly
+  ans2dev.general.udevadm_trigger:
+    type: all
+    quiet: true
+  register: result_all_quiet
+
+- name: Assert quiet trigger succeeded with no stderr
+  ansible.builtin.assert:
+    that:
+      - result_all_quiet.udevtrigger.stderr == ""
+    success_msg: "Quiet trigger ran cleanly"
+    fail_msg: "Quiet trigger produced errors"
+
+- name: Trigger only device events without quiet
+  ans2dev.general.udevadm_trigger:
+    type: devices
+    quiet: false
+  register: result_devices
+
+- name: Assert device trigger stdout exist
+  ansible.builtin.assert:
+    that:
+      - result_devices.udevtrigger.stdout is defined
+    success_msg: "Device-trigger stdout looks good"
+    fail_msg: "Device-trigger stdout was empty"
+
+- name: Trigger only subsystem events quietly
+  ans2dev.general.udevadm_trigger:
+    type: subsystems
+    quiet: true
+  register: result_subsystems
+
+- name: Assert subsystem trigger succeeded with no stderr
+  ansible.builtin.assert:
+    that:
+      - result_subsystems.udevtrigger.stderr == ""
+    success_msg: "Subsystem-trigger ran cleanly"
+    fail_msg: "Subsystem-trigger produced errors"

--- a/tests/unit/plugins/modules/test_udevadm_trigger.py
+++ b/tests/unit/plugins/modules/test_udevadm_trigger.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from ansible_collections.ans2dev.general.plugins.modules import udevadm_trigger  # type: ignore
+
+
+def exit_json(*args, **kwargs):
+    raise Exception("exit_json called: " + str(kwargs))
+
+
+def fail_json(*args, **kwargs):
+    raise Exception("fail_json called: " + str(kwargs))
+
+
+class TestUdevadmTriggerModule(unittest.TestCase):
+    def setUp(self):
+        patcher = patch(
+            'ansible_collections.ans2dev.general.plugins.modules.udevadm_trigger.AnsibleModule'
+        )
+        self.mock_module_class = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.fake_module = MagicMock()
+        self.fake_module.exit_json.side_effect = exit_json
+        self.fake_module.fail_json.side_effect = fail_json
+        self.mock_module_class.return_value = self.fake_module
+
+    def run_main(self):
+        with self.assertRaises(Exception) as context:
+            udevadm_trigger.main()
+        return str(context.exception)
+
+    def test_with_quiet(self):
+        self.fake_module.params = {'type': 'all', 'quiet': True}
+        self.fake_module.check_mode = False
+        self.fake_module.get_bin_path.return_value = '/usr/bin/udevadm'
+        self.fake_module.run_command.return_value = (0, 'triggered', '')
+
+        result = self.run_main()
+        self.assertIn("'changed': True", result)
+        self.assertIn("'stdout': 'triggered'", result)
+        self.assertIn("'stderr': ''", result)
+
+    def test_without_quiet(self):
+        self.fake_module.params = {'type': 'devices', 'quiet': False}
+        self.fake_module.check_mode = False
+        self.fake_module.get_bin_path.return_value = '/usr/bin/udevadm'
+        self.fake_module.run_command.return_value = (0, 'done', '')
+
+        result = self.run_main()
+        self.assertIn("'changed': True", result)
+        self.assertIn("'stdout': 'done'", result)
+        self.assertIn("'stderr': ''", result)
+
+    def test_fail_nonzero(self):
+        self.fake_module.params = {'type': 'subsystems', 'quiet': False}
+        self.fake_module.check_mode = False
+        self.fake_module.get_bin_path.return_value = '/usr/bin/udevadm'
+        self.fake_module.run_command.return_value = (2, '', 'error')
+
+        result = self.run_main()
+        self.assertIn('fail_json called', result)
+        self.assertIn('error', result)
+
+    def test_check_mode(self):
+        self.fake_module.params = {'type': 'all', 'quiet': False}
+        self.fake_module.check_mode = True
+
+        result = self.run_main()
+        self.assertIn("'changed': False", result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds the new **`udevadm_trigger`** module.

- Added new `module`
- Added new `unit` test
- Added new `integration` test
- Added new entry in `BOTMETA.yml`

Examples:

```yaml
# Trigger all events
- name: Trigger all events
  ans2dev.general.udevadm_trigger:
    quiet: true
    type: all
  register: result

# Trigger devices events without quiet
- name: Trigger all events
  ans2dev.general.udevadm_trigger:
    quiet: false
    type: devices
  register: result

# Trigger subsystems events
- name: Trigger all events
  ans2dev.general.udevadm_trigger:
    quiet: true
    type: subsystems
  register: result
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
udevadm_trigger
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```