### PR TITLE
charts - restrict plotly version to <= 6.0.1

### DIFF
--- a/changelogs/fragments/184-charts-restrict-plotly.yml
+++ b/changelogs/fragments/184-charts-restrict-plotly.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - charts - restrict ``plotly`` version to < ``6.1.0`` (https://github.com/3A2DEV/ans2dev.general/pull/184).

--- a/plugins/modules/charts.py
+++ b/plugins/modules/charts.py
@@ -19,7 +19,7 @@ description:
 version_added: "0.1.0"
 requirements:
   - requests
-  - plotly
+  - plotly < 6.1.0
   - kaleido
 options:
   titlechart:

--- a/roles/install_dep/files/requirements.txt
+++ b/roles/install_dep/files/requirements.txt
@@ -1,4 +1,4 @@
 requests
 kaleido
-plotly
+plotly <= '6.0.1'
 openpyxl

--- a/roles/install_dep/files/requirements.txt
+++ b/roles/install_dep/files/requirements.txt
@@ -1,4 +1,4 @@
 requests
 kaleido
-plotly <= '6.0.1'
+plotly < '6.1'
 openpyxl

--- a/roles/install_dep/files/requirements.txt
+++ b/roles/install_dep/files/requirements.txt
@@ -1,4 +1,4 @@
 requests
 kaleido
-plotly < '6.1'
+plotly<'6.1.0'
 openpyxl

--- a/roles/install_dep/files/requirements.txt
+++ b/roles/install_dep/files/requirements.txt
@@ -1,4 +1,4 @@
 requests
 kaleido
-plotly<'6.1.0'
+plotly < 6.1.0
 openpyxl

--- a/tests/integration/targets/charts/tasks/tests.yml
+++ b/tests/integration/targets/charts/tasks/tests.yml
@@ -7,7 +7,7 @@
     name:
       - requests
       - kaleido
-      - plotly==6.0.1
+      - plotly<6.1.0
 
 - name: Generate a line chart
   ans2dev.general.charts:

--- a/tests/integration/targets/charts/tasks/tests.yml
+++ b/tests/integration/targets/charts/tasks/tests.yml
@@ -7,7 +7,7 @@
     name:
       - requests
       - kaleido
-      - plotly
+      - plotly==6.0.1
 
 - name: Generate a line chart
   ans2dev.general.charts:

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -8,4 +8,4 @@ openpyxl
 # requirement for the charts module
 requests
 kaleido
-plotly<'6.1.0'
+plotly < 6.1.0

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -8,4 +8,4 @@ openpyxl
 # requirement for the charts module
 requests
 kaleido
-plotly
+plotly <= '6.0.1'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -8,4 +8,4 @@ openpyxl
 # requirement for the charts module
 requests
 kaleido
-plotly <= '6.0.1'
+plotly < '6.1'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -8,4 +8,4 @@ openpyxl
 # requirement for the charts module
 requests
 kaleido
-plotly < '6.1'
+plotly<'6.1.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR restrict plotly version to <= `6.0.1`

From new `6.1.0` charts module not work

```shell
TASK [charts : Assert that all chart image files exist and are non-empty] ******
fatal: [testhost]: FAILED! => {
    "assertion": "line_chart_file.stat.exists",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
charts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```